### PR TITLE
Improve use of existing Symfony Service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         }
     },
     "minimum-stability": "stable",
+    "require": {
+        "php": ">=7.3"
+    },
     "require-dev": {
         "phpunit/phpunit": "^9.1",
         "phpspec/prophecy-phpunit": "^2",

--- a/src/Areabricks/AbstractAreabrick.php
+++ b/src/Areabricks/AbstractAreabrick.php
@@ -116,6 +116,14 @@ abstract class AbstractAreabrick extends AbstractTemplateAreabrick
     }
 
     /**
+     * @codeCoverageIgnore
+     * @param array<string, mixed> $options
+     */
+    public function configure(array $options): void
+    {
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @codeCoverageIgnore

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,13 @@ class Configuration implements ConfigurationInterface
             ->info('Use a predefined service instead of a newly created one.')
             ->end();
         $builder
+            ->arrayNode('options')
+                ->info('Set options for areabrick. (Makes only sense in combination with `class`)')
+                ->useAttributeAsKey('name')
+                ->scalarPrototype()
+                ->end()
+            ->end();
+        $builder
             ->scalarNode('label')
             ->info('Specify a label for the admin UI.')
             ->end();

--- a/src/DependencyInjection/PimcoreRadBrickExtension.php
+++ b/src/DependencyInjection/PimcoreRadBrickExtension.php
@@ -59,20 +59,25 @@ class PimcoreRadBrickExtension extends Extension
         $container->setDefinition(AreabrickRenderer::class, $rendererDefinition);
 
         $areabricks = $config['areabricks'];
-        foreach ($areabricks as $id => $aconfig) {
-            $target = null;
+        foreach ($areabricks as $id => $areabrickConfig) {
             $definitionId = 'radbrick.'.$id;
-            if ($class = $aconfig['class']) {
-                $definitionId = $class;
-                $target = $container->getDefinition($class);
+            $parent = null;
+            $options = $areabrickConfig['options'] ?: [];
+
+            $target = null;
+            if ($class = $areabrickConfig['class']) {
+                $target = clone $container->getDefinition($class);
+                $target->setAbstract(false);
             }
 
             if (!$target) {
-                $target = new Definition(
-                    SimpleBrick::class,
-                    [$id, new Reference(AreabrickRenderer::class)]
-                );
+                $target = new Definition(SimpleBrick::class);
             }
+
+            $target->setArgument('name', $id);
+            $target->setArgument('areabrickRenderer', new Reference(AreabrickRenderer::class));
+
+            $target->addMethodCall('configure', [$options]);
 
             if (!$target->hasTag('pimcore.area.brick')) {
                 $target->addTag('pimcore.area.brick', ['id' => $id]);

--- a/tests/DependencyInjection/PimcoreRadBrickExtensionTest.php
+++ b/tests/DependencyInjection/PimcoreRadBrickExtensionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Khusseini\PimcoreRadBrickBundle\DependencyInjection;
+
+use Khusseini\PimcoreRadBrickBundle\Areabricks\AbstractAreabrick;
+use Khusseini\PimcoreRadBrickBundle\DependencyInjection\PimcoreRadBrickExtension;
+use PHPStan\Testing\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Yaml\Yaml;
+
+class ExampleBaseAreabrick extends AbstractAreabrick
+{
+    private $options;
+
+    public function configure(array $options): void
+    {
+        $this->options = $options;
+    }
+}
+
+class PimcoreRadBrickExtensionTest extends TestCase
+{
+    public function examplesDataProdiver()
+    {
+        return [
+            $this->getBaseClassExampleData(),
+        ];
+    }
+
+    /**
+     * @dataProvider examplesDataProdiver
+     */
+    public function testExamples(
+        string $configFile,
+        ContainerBuilder $containerBuilder,
+        callable $customAssert = null
+    ) {
+        $extension = new PimcoreRadBrickExtension();
+        $configs = Yaml::parseFile(__DIR__.'/config/'.$configFile);
+        $extension->load($configs, $containerBuilder);
+        $areabricks = $configs['pimcore_rad_brick']['areabricks'];
+
+        foreach ($areabricks as $name => $config) {
+            $this->assertTrue($containerBuilder->has('radbrick.'.$name));
+        }
+
+        if ($customAssert) {
+            $customAssert($configs['pimcore_rad_brick'], $containerBuilder);
+        }
+    }
+
+    private function getBaseClassExampleData(): array
+    {
+        $containerBuilder = new ContainerBuilder();
+        $baseDefinition = new Definition();
+        $baseDefinition->setAbstract(true);
+        $baseDefinition->setClass(ExampleBaseAreabrick::class);
+
+        $containerBuilder->setDefinition(
+            'app.areabricks.base.example_custom_brick',
+            $baseDefinition
+        );
+
+        return [
+            'base_class.yml',
+            $containerBuilder
+        ];
+    }
+}

--- a/tests/DependencyInjection/config/base_class.yml
+++ b/tests/DependencyInjection/config/base_class.yml
@@ -1,0 +1,6 @@
+pimcore_rad_brick:
+  areabricks:
+    example_with_base_service:
+      class: 'app.areabricks.base.example_custom_brick'
+      options:
+        hello: 'world'


### PR DESCRIPTION
- Added 'option' key to configuration.
- Base services must be defined as abstract as they serve as a parent for configured areabricks.
- Added tests to validate the symfony container builder definition.